### PR TITLE
split out ownable implementation into separate contract

### DIFF
--- a/contracts/Diamond.sol
+++ b/contracts/Diamond.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.24;
 
 import {IDiamondCut} from "./interfaces/IDiamondCut.sol";
 import {DiamondImpl} from "./impls/DiamondImpl.sol";
+import {OwnableImpl} from "./impls/OwnableImpl.sol";
 
 error FunctionNotFound(bytes4 _selector);
 
-contract Diamond is DiamondImpl {
+contract Diamond is DiamondImpl, OwnableImpl {
     struct Args {
         address owner;
         address init;

--- a/contracts/facets/DiamondCutFacet.sol
+++ b/contracts/facets/DiamondCutFacet.sol
@@ -2,12 +2,13 @@
 pragma solidity ^0.8.24;
 
 import {DiamondImpl} from "../impls/DiamondImpl.sol";
+import {OwnableImpl} from "../impls/OwnableImpl.sol";
 import {IDiamondCut} from "../interfaces/IDiamondCut.sol";
 
 // WARNING: The functions in DiamondCutFacet MUST be added to a diamond. The
 // EIP-2535 Diamond standard requires these functions.
 
-contract DiamondCutFacet is IDiamondCut, DiamondImpl {
+contract DiamondCutFacet is IDiamondCut, DiamondImpl, OwnableImpl {
     /// @inheritdoc IDiamondCut
     function diamondCut(
         FacetCut[] calldata _cuts,

--- a/contracts/facets/OwnableFacet.sol
+++ b/contracts/facets/OwnableFacet.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {DiamondImpl} from "../impls/DiamondImpl.sol";
+import {OwnableImpl} from "../impls/OwnableImpl.sol";
 import {IERC173} from "../interfaces/IERC173.sol";
 
-contract OwnershipFacet is IERC173, DiamondImpl {
+contract OwnableFacet is IERC173, OwnableImpl {
     function transferOwnership(address _newOwner) external override {
         _checkIsOwner();
         _setOwner(_newOwner);

--- a/contracts/impls/DiamondImpl.sol
+++ b/contracts/impls/DiamondImpl.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.24;
 
 import {IDiamond} from "../interfaces/IDiamond.sol";
 import {IDiamondCut} from "../interfaces/IDiamondCut.sol";
-import {IERC173} from "../interfaces/IERC173.sol";
 
 error CannotAddSelectorThatAlreadyExists(bytes4 _selector);
 error CannotAddSelectorsFromZeroAddress(bytes4[] _selectors);
@@ -17,7 +16,6 @@ error InitializationFunctionReverted(address _initializationContractAddress, byt
 error InvalidFacetCutAction(uint8 _action);
 error NoBytecodeAtAddress(address _address);
 error NoSelectorsProvidedForFacetForCut(address _facetAddress);
-error NotContractOwner(address _user, address _owner);
 error RemoveFacetAddressMustBeZeroAddress(address _facetAddress);
 
 abstract contract DiamondImpl {
@@ -31,7 +29,6 @@ abstract contract DiamondImpl {
         // function selector => facet address and selector position in selectors array
         mapping(bytes4 => FacetAddressAndSelectorPosition) facetAddressAndSelectorPosition;
         bytes4[] selectors;
-        address owner;
     }
 
     // keccak256(abi.encode(uint256(keccak256("silverkoi.diamond.storage.diamond")) - 1)) & ~bytes32(uint256(0xff));
@@ -42,23 +39,6 @@ abstract contract DiamondImpl {
         // solhint-disable no-inline-assembly
         assembly {
             $.slot := STORAGE_LOCATION
-        }
-    }
-
-    function _setOwner(address _newOwner) internal {
-        DiamondStorage storage s = _getDiamondStorage();
-        address previousOwner = s.owner;
-        s.owner = _newOwner;
-        emit IERC173.OwnershipTransferred(previousOwner, _newOwner);
-    }
-
-    function _owner() internal view returns (address owner_) {
-        owner_ = _getDiamondStorage().owner;
-    }
-
-    function _checkIsOwner() internal view {
-        if (msg.sender != _getDiamondStorage().owner) {
-            revert NotContractOwner(msg.sender, _getDiamondStorage().owner);
         }
     }
 

--- a/contracts/impls/OwnableImpl.sol
+++ b/contracts/impls/OwnableImpl.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC173} from "../interfaces/IERC173.sol";
+
+error NotContractOwner(address _user, address _owner);
+
+abstract contract OwnableImpl {
+    /// @custom:storage-location erc7201:silverkoi.diamond.storage.ownable
+    struct OwnableStorage {
+        address owner;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("silverkoi.diamond.storage.ownable")) - 1)) & ~bytes32(uint256(0xff));
+    bytes32 private constant STORAGE_LOCATION =
+        0x0be3d9d83d2b0f043dd4da92e8b82c04b982e5bd83fdbf1e548b99284066d100;
+
+    function _getOwnableStorage() internal pure returns (OwnableStorage storage $) {
+        // solhint-disable no-inline-assembly
+        assembly {
+            $.slot := STORAGE_LOCATION
+        }
+    }
+
+    function _setOwner(address _newOwner) internal {
+        OwnableStorage storage s = _getOwnableStorage();
+        address previousOwner = s.owner;
+        s.owner = _newOwner;
+        emit IERC173.OwnershipTransferred(previousOwner, _newOwner);
+    }
+
+    function _owner() internal view returns (address owner_) {
+        owner_ = _getOwnableStorage().owner;
+    }
+
+    function _checkIsOwner() internal view {
+        if (msg.sender != _getOwnableStorage().owner) {
+            revert NotContractOwner(msg.sender, _getOwnableStorage().owner);
+        }
+    }
+}

--- a/tests/Diamond.t.sol
+++ b/tests/Diamond.t.sol
@@ -5,12 +5,13 @@ import {Test, console2} from "forge-std/Test.sol";
 import {Diamond, FunctionNotFound} from "../contracts/Diamond.sol";
 import {DiamondCutFacet} from "../contracts/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../contracts/facets/DiamondLoupeFacet.sol";
-import {OwnershipFacet} from "../contracts/facets/OwnershipFacet.sol";
+import {OwnableFacet} from "../contracts/facets/OwnableFacet.sol";
 import {IDiamond} from "../contracts/interfaces/IDiamond.sol";
 import {IERC173} from "../contracts/interfaces/IERC173.sol";
 import {IDiamondCut} from "../contracts/interfaces/IDiamondCut.sol";
 import {IDiamondLoupe} from "../contracts/interfaces/IDiamondLoupe.sol";
 import "../contracts/impls/DiamondImpl.sol";
+import "../contracts/impls/OwnableImpl.sol";
 
 import "./TestContracts.sol";
 

--- a/tests/TestContracts.sol
+++ b/tests/TestContracts.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import {Diamond, FunctionNotFound} from "../contracts/Diamond.sol";
 import {DiamondCutFacet} from "../contracts/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../contracts/facets/DiamondLoupeFacet.sol";
-import {OwnershipFacet} from "../contracts/facets/OwnershipFacet.sol";
+import {OwnableFacet} from "../contracts/facets/OwnableFacet.sol";
 import {IDiamond} from "../contracts/interfaces/IDiamond.sol";
 import {IERC173} from "../contracts/interfaces/IERC173.sol";
 import {IDiamondCut} from "../contracts/interfaces/IDiamondCut.sol";
@@ -229,13 +229,13 @@ contract TestHelper {
         }
         {
             bytes4[] memory selectors;
-            selectors = _append(selectors, OwnershipFacet.owner.selector);
-            selectors = _append(selectors, OwnershipFacet.transferOwnership.selector);
+            selectors = _append(selectors, OwnableFacet.owner.selector);
+            selectors = _append(selectors, OwnableFacet.transferOwnership.selector);
 
             cuts = _append(
                 cuts,
                 IDiamond.FacetCut({
-                    facetAddress: address(new OwnershipFacet()),
+                    facetAddress: address(new OwnableFacet()),
                     action: IDiamond.FacetCutAction.Add,
                     functionSelectors: selectors
                 })

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -16,7 +16,7 @@ export async function deployFacets(): Promise<FacetCut[]> {
   return [
     await deployFacetAndGetCut("DiamondCutFacet"),
     await deployFacetAndGetCut("DiamondLoupeFacet"),
-    await deployFacetAndGetCut("OwnershipFacet"),
+    await deployFacetAndGetCut("OwnableFacet"),
     await deployFacetAndGetCut("Example1FacetV0"),
     await deployFacetAndGetCut("Example2Facet"),
     await deployFacetAndGetCut("ExampleInit", ["initialize"]),

--- a/tests/ownership.test.ts
+++ b/tests/ownership.test.ts
@@ -14,7 +14,7 @@ describe("Ownership", function () {
   it("cannot transfer ownership if not owner", async function () {
     const { diamond, owner, notOwner, user } = await loadFixture(deployDiamond)
     const c = await ethers.getContractAt("IERC173", diamond)
-    const errorContract = await ethers.getContractAt("OwnershipFacet", "0x0")
+    const errorContract = await ethers.getContractAt("OwnableFacet", "0x0")
     await expect(c.connect(notOwner).transferOwnership(user))
       .to.be.revertedWithCustomError(errorContract, "NotContractOwner")
       .withArgs(notOwner, owner)


### PR DESCRIPTION
Move ownable implementation to separate impl contract so that it can be reused directly by other implementations without having to pull in diamond-related code.